### PR TITLE
feat(text_painter): add maxLines and isEllipsis support in SpoilerTex…

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,6 +78,8 @@ class _MainAppState extends State<MainApp> {
                     color: Colors.white,
                   ),
                   maskConfig: createStarPath(const Size.square(80), const Offset(230, 30)),
+                  maxLines: 1,
+                  isEllipsis: true
                 ),
                 text: text,
               ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,8 +78,8 @@ class _MainAppState extends State<MainApp> {
                     color: Colors.white,
                   ),
                   maskConfig: createStarPath(const Size.square(80), const Offset(230, 30)),
-                  maxLines: 1,
-                  isEllipsis: true
+                  // maxLines: 1,
+                  // isEllipsis: true
                 ),
                 text: text,
               ),

--- a/lib/models/text_spoiler_configs.dart
+++ b/lib/models/text_spoiler_configs.dart
@@ -26,6 +26,29 @@ class TextSpoilerConfig extends SpoilerConfig {
   /// If null, the default alignment of the parent widget will be used.
   final TextAlign? textAlign;
 
+  /// An optional maximum number of lines for the text to span, wrapping if necessary.
+  ///
+  /// If the text exceeds the given number of lines, it will be truncated according
+  /// to [isEllipsis].
+  ///
+  /// If this is 1, the text will not wrap. Otherwise, text will wrap at the
+  /// edge of the box.
+  ///
+  /// If this is null, but there is an ambient [DefaultTextStyle] that specifies
+  /// an explicit number for its [DefaultTextStyle.maxLines], then the
+  /// [DefaultTextStyle] value will take precedence. You can use a [RichText]
+  /// widget directly to entirely override the [DefaultTextStyle].
+  final int? maxLines;
+
+  /// Determines whether overflowing text should display an ellipsis ("…") at the end.
+  ///
+  /// If [isEllipsis] is true and the text exceeds [maxLines], a "…" will be
+  /// appended to indicate that the text has been truncated.
+  ///
+  /// If null or false, overflowing text will be clipped or handled according
+  /// to the [overflow] or default behavior.
+  final bool? isEllipsis;
+
   /// Creates a text spoiler configuration with the specified parameters.
   ///
   /// Inherits base properties from [SpoilerConfig] while adding
@@ -34,6 +57,8 @@ class TextSpoilerConfig extends SpoilerConfig {
     this.textStyle,
     this.textSelection,
     this.textAlign,
+    this.maxLines,
+    this.isEllipsis,
     super.particleDensity = 20.0,
     super.particleSpeed = 0.2,
     super.particleColor = Colors.white70,

--- a/lib/models/text_spoiler_configs.dart
+++ b/lib/models/text_spoiler_configs.dart
@@ -45,8 +45,7 @@ class TextSpoilerConfig extends SpoilerConfig {
   /// If [isEllipsis] is true and the text exceeds [maxLines], a "…" will be
   /// appended to indicate that the text has been truncated.
   ///
-  /// If null or false, overflowing text will be clipped or handled according
-  /// to the [overflow] or default behavior.
+  /// If the value is null or false, the ellipsis will not be used
   final bool? isEllipsis;
 
   /// Creates a text spoiler configuration with the specified parameters.

--- a/lib/spoiler_text_widget.dart
+++ b/lib/spoiler_text_widget.dart
@@ -59,6 +59,8 @@ class _SpoilerTextState extends State<SpoilerText> with TickerProviderStateMixin
             textSelection: widget.config.textSelection,
             textAlign: widget.config.textAlign ?? TextAlign.start,
             style: widget.config.textStyle,
+            maxLines: widget.config.maxLines,
+            isEllipsis: widget.config.isEllipsis,
             onPaint: (canvas, size) {
               if (_spoilerController.isEnabled) {
                 _spoilerController.drawParticles(canvas);
@@ -82,6 +84,8 @@ class SpoilerTextPainter extends StatefulWidget {
     required this.textAlign,
     this.style,
     this.textSelection,
+    this.maxLines,
+    this.isEllipsis,
     Key? key,
   }) : super(key: key);
 
@@ -91,6 +95,8 @@ class SpoilerTextPainter extends StatefulWidget {
   final TextAlign textAlign;
   final ValueChanged<List<Rect>> onInit;
   final PaintCallback onPaint;
+  final int? maxLines;
+  final bool? isEllipsis;
 
   @override
   State<SpoilerTextPainter> createState() => _SpoilerTextPainterState();
@@ -148,6 +154,8 @@ class _SpoilerTextPainterState extends State<SpoilerTextPainter> {
           text: TextSpan(text: widget.text, style: widget.style),
           textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
           textAlign: widget.textAlign,
+          maxLines: widget.maxLines,
+          ellipsis: widget.isEllipsis == true ? '...' : null,
         );
         textPainter.layout(maxWidth: constraints.maxWidth);
         final textSize = Size(textPainter.width, textPainter.height);


### PR DESCRIPTION
feat(text_painter): add maxLines and isEllipsis support in SpoilerTextPainter

- Added `maxLines` parameter to limit the number of text lines.
- Added `isEllipsis` boolean to optionally append "…" for overflowing text.
- Updated TextPainter initialization to handle ellipsis correctly.
- Adjusted CustomPaint logic to support fade, clip, visible, and ellipsis overflow.
- Added documentation comments for maxLines and isEllipsis explaining their behavior.